### PR TITLE
feat: enhance home with healing and potion shop

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       <div class="meta">
         <span id="floorLabel">Home</span>
         <span>Poké Balls: <b id="pokeballs">0</b></span>
+        <span>Potions: <b id="potions">0</b></span>
         <span>₽ <b id="money">0</b></span>
       </div>
       <div class="actions">

--- a/js/battle.js
+++ b/js/battle.js
@@ -174,10 +174,12 @@ const Battle = {
 
   defeat(state){
     Log.write('You were defeated. Returning home. Progress persists.');
-    state.mode='home';
-    state.party.forEach(p=>{ p.hp=p.maxhp; });
+    state.mode = 'home';
     state.items.pokeball = Math.max(state.items.pokeball, 3);
     updateMetaUI(state);
     Storage.save(state);
+    if (typeof Game !== 'undefined' && Game.showHome) {
+      Game.showHome();
+    }
   }
 };

--- a/js/main.js
+++ b/js/main.js
@@ -68,7 +68,23 @@ const Game = {
 
   showHome(initial=false){
     this.state.mode = 'home';
+
+    // Heal the party when returning home
+    this.state.party.forEach(p => {
+      p.hp = p.maxhp;
+      p.status = null;
+      p.fainted = false;
+      if (Array.isArray(p.moves)) {
+        p.moves.forEach(m => { m.pp = m.ppMax || m.pp; });
+      }
+    });
+    renderParty(this.state.party);
+
+    Log.write('All Pokémon have been healed.');
+
     updateMetaUI(this.state);
+    Storage.save(this.state);
+
     if (window.AudioMgr) AudioMgr.play('amb', {loop:true, volume:0.25});
 
     homeScreen(async (maybeStarter) => {

--- a/js/ui.js
+++ b/js/ui.js
@@ -20,12 +20,25 @@ function homeScreen(onStart){
       <button id="btnStartRaid" class="btn-wide">Enter Dungeon</button>
       <button id="btnPickStarter" class="btn-wide">Choose Starter</button>
       <button id="btnDexFull" class="btn-wide">Pokédex</button>
+      <button id="btnBuyPotion" class="btn-wide">Buy Potion (₽100)</button>
     </div>
     <p class="small">Tip: WASD to move, arrow keys or mouse drag to turn.</p>`;
   const m = modal(html, {title:"Home"});
   m.querySelector('#btnStartRaid').onclick = ()=>{ m.classList.add('hidden'); m.innerHTML=''; onStart(); };
   m.querySelector('#btnPickStarter').onclick = ()=>{ pickStarter((p)=>{ onStart(p); }); };
   m.querySelector('#btnDexFull').onclick = ()=> showPokedexFull();
+  m.querySelector('#btnBuyPotion').onclick = ()=>{
+    const cost = 100;
+    if ((Game.state.money||0) >= cost){
+      Game.state.money -= cost;
+      Game.state.items.potion = (Game.state.items.potion||0) + 1;
+      Log.write('Bought a potion.');
+      updateMetaUI(Game.state);
+      Storage.save(Game.state);
+    } else {
+      Log.write('Not enough money.');
+    }
+  };
 }
 
 function pickStarter(onPick){
@@ -63,7 +76,8 @@ function renderParty(party){
 
 function updateMetaUI(state){
   document.getElementById('pokeballs').textContent = state.items.pokeball;
-  document.getElementById('money').textContent = state.money;
+  document.getElementById('potions').textContent   = state.items.potion;
+  document.getElementById('money').textContent     = state.money;
   const label = state.mode==='home' ? 'Home' : ('Floor ' + state.floor);
   document.getElementById('floorLabel').textContent = `${label}   |   Trainer Lv ${state.playerLevel||1}`;
 }


### PR DESCRIPTION
## Summary
- Heal and restore party when returning home
- Add potion inventory display and purchasing at home
- Trigger home screen after defeat

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689724675b28832499e17d12ec84d35c